### PR TITLE
EDP-45 adding database name for sequelize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           env_vars: |
             NODE_ENV=${{ secrets.NODE_ENV }}
             STAGING_DB_USERNAME=${{ secrets.STAGING_DB_USERNAME }}
+            STAGING_DB_NAME=${{ secrets.STAGING_DB_USERNAME }}
             STAGING_DB_PASSWORD=${{ secrets.STAGING_DB_PASSWORD }}
             STAGING_DB_HOST=${{ secrets.STAGING_DB_HOST }}
             STAGING_DB_PORT=${{ secrets.STAGING_DB_PORT }}


### PR DESCRIPTION
The issue is cause because in the CI/CD script the database name is not added so the server is reading default as "postgres" instead of the real database name secret