### PR TITLE
[Experiment] EDP-106 delete profile avatar 

### DIFF
--- a/src/controllers/profile/avatar/delete.controller.js
+++ b/src/controllers/profile/avatar/delete.controller.js
@@ -1,0 +1,29 @@
+const { Profile } = require("../../../models");
+const { deleteUploaded } = require("../../../utils/imagekit.utils");
+const { response } = require("../../../utils/response.utils");
+
+const deleteAvatar = async (req, res) => {
+  try {
+    const user = req.user;
+    const { avatar_link } = await Profile.findOne({
+      where: { user_id: user.id },
+      attributes: ["avatar_link"],
+    });
+    const APIresponse = await deleteUploaded(avatar_link);
+    await Profile.update(
+      { avatar_link: null },
+      { where: { user_id: user.id } }
+    );
+    return response(
+      res,
+      200,
+      true,
+      "Successfully Deleted",
+      APIresponse.result.message
+    );
+  } catch (err) {
+    return response(res, err.status || 500, false, err.result.message, null);
+  }
+};
+
+module.exports = deleteAvatar;

--- a/src/controllers/profile/avatar/upload.controller.js
+++ b/src/controllers/profile/avatar/upload.controller.js
@@ -1,7 +1,6 @@
-const { User, Profile } = require("../../models");
-const { singleUpload } = require("../../utils/imagekit.utils");
-const { response } = require("../../utils/response.utils");
-const path = require("path");
+const { User, Profile } = require("../../../models");
+const { singleUpload } = require("../../../utils/imagekit.utils");
+const { response } = require("../../../utils/response.utils");
 
 const upAvatar = async (req, res) => {
   try {

--- a/src/controllers/profile/index.js
+++ b/src/controllers/profile/index.js
@@ -1,11 +1,13 @@
 const whoami = require("./whoami.controller");
 const updateUser = require("./update.controller");
 const deleteUser = require("./delete.controller");
-const upAvatar = require("./avatar.controller");
+const upAvatar = require("./avatar/upload.controller");
+const deleteAvatar = require("./avatar/delete.controller");
 
 module.exports = {
   whoami,
   updateUser,
   deleteUser,
   upAvatar,
+  deleteAvatar,
 };

--- a/src/routes/profile/avatar/avatar.route.js
+++ b/src/routes/profile/avatar/avatar.route.js
@@ -1,0 +1,15 @@
+const router = require("express").Router();
+const controller = require("../../../controllers/profile");
+const middleware = require("../../../middlewares");
+const { MODULE } = require("../../../utils/enum.utils");
+const { image } = require("../../../configs/multer.config");
+
+router.post(
+  "/",
+  middleware.restrict,
+  image.single("avatar"),
+  controller.upAvatar
+);
+router.delete("/", middleware.restrict, controller.deleteAvatar);
+
+module.exports = router;

--- a/src/routes/profile/profile.route.js
+++ b/src/routes/profile/profile.route.js
@@ -2,7 +2,7 @@ const router = require("express").Router();
 const controller = require("../../controllers/profile");
 const middleware = require("../../middlewares");
 const { MODULE } = require("../../utils/enum.utils");
-const { image, document } = require("../../configs/multer.config");
+const avatar = require("./avatar/avatar.route");
 
 router.get(
   "/",
@@ -16,12 +16,7 @@ router.put(
   middleware.rbac(MODULE.LANDING, true, false),
   controller.updateUser
 );
-router.post(
-  "/avatar",
-  middleware.restrict,
-  image.single("avatar"),
-  controller.upAvatar
-);
+router.use("/avatar", avatar);
 router.delete("/", controller.deleteUser);
 
 module.exports = router;

--- a/src/utils/imagekit.utils.js
+++ b/src/utils/imagekit.utils.js
@@ -1,4 +1,4 @@
-const imagekit = require('../configs/imagekit.config')
+const imagekit = require("../configs/imagekit.config");
 const { response } = require("../utils/response.utils");
 const path = require("path");
 
@@ -33,4 +33,33 @@ const multiUpload = async (req, res) => {
   }
 };
 
-module.exports = { singleUpload, multiUpload}
+/** TODO: delete the uploaded image from the imagekit host because,
+ * the problem is that the imagekit return 403 meanwhile we have the
+ * authorized key for deleting the image
+ * documentation: https://docs.imagekit.io/api-reference/media-api/delete-file
+ * I've read some issues that other person also cannot delete their image from the
+ * imagekit host such as: https://www.pythonanywhere.com/forums/topic/27752/.
+ */
+const deleteUploaded = (url) => {
+  const fileId = url.split("/").pop();
+
+  /** File Without extensions, possible way, but still got 403 */
+  //let extensionIndex = filename.lastIndexOf(".");
+  //let fileId = filename.substring(0, extensionIndex);
+
+  let APIresponse = { sucess: null, result: null };
+
+  return new Promise((resolve, reject) => {
+    imagekit.deleteFile(fileId, function (err, result) {
+      if (err) {
+        APIresponse = { success: false, result: err };
+        reject(APIresponse);
+      } else {
+        APIresponse = { success: true, result: result };
+        resolve(APIresponse);
+      }
+    });
+  });
+};
+
+module.exports = { singleUpload, multiUpload, deleteUploaded };


### PR DESCRIPTION
This feature is still an experiment to reduce the storage in the imagekit if the user want to delete the file or updating the profile so the storage in imagekit is not full.

The problem is within the API for deletion cannot be performed, the demonstration for performing this API is in the below gif, I also provide the details on the code. 

![avatar-deletion-bg](https://github.com/Belega-Village-UNUD/backend-api-edb/assets/75294452/0d0993d5-8cf7-47fd-b100-fd33d7e97b2b)

