### PR TITLE
EDP-110 fix: OTP expired immediately

### DIFF
--- a/src/configs/otp.config.js
+++ b/src/configs/otp.config.js
@@ -40,6 +40,8 @@ const verifyOTP = async (user, otp) => {
   const createdAt = moment(otpDB.createdAt);
   const now = moment();
   const minutesPass = now.diff(createdAt, "m");
+  const updatedAt = moment.utc(otpDB.updatedAt);
+  const minutesPass = now.diff(updatedAt, "m");
   if (minutesPass >= 1) {
     console.log("OTP expired");
     return {

--- a/src/configs/otp.config.js
+++ b/src/configs/otp.config.js
@@ -37,9 +37,6 @@ const verifyOTP = async (user, otp) => {
       message: "OTP expired, please request another OTP Code",
     };
 
-  const createdAt = moment(otpDB.createdAt);
-  const now = moment();
-  const minutesPass = now.diff(createdAt, "m");
   const updatedAt = moment.utc(otpDB.updatedAt);
   const now = moment().utc();
   const minutesPass = now.diff(updatedAt, "m");

--- a/src/configs/otp.config.js
+++ b/src/configs/otp.config.js
@@ -41,6 +41,7 @@ const verifyOTP = async (user, otp) => {
   const now = moment();
   const minutesPass = now.diff(createdAt, "m");
   const updatedAt = moment.utc(otpDB.updatedAt);
+  const now = moment().utc();
   const minutesPass = now.diff(updatedAt, "m");
   if (minutesPass >= 1) {
     console.log("OTP expired");

--- a/src/configs/otp.config.js
+++ b/src/configs/otp.config.js
@@ -41,7 +41,6 @@ const verifyOTP = async (user, otp) => {
   const now = moment().utc();
   const minutesPass = now.diff(updatedAt, "m");
   if (minutesPass >= 1) {
-    console.log("OTP expired");
     return {
       success: false,
       message: "OTP expired, please request another OTP Code",


### PR DESCRIPTION
# Fix OTP Expiry

- changing the column query
- change to UTC

before:
![image](https://github.com/Belega-Village-UNUD/backend-api-edb/assets/75294452/c5954cb3-9f48-4fcb-bddf-5a2a6baf10d4)

after:
![image](https://github.com/Belega-Village-UNUD/backend-api-edb/assets/75294452/df4cd48b-a06d-4cb3-b5e4-939370c222ca)

*notice the time at `createdAt` variable, it queries to the old time therefore when compared it expires immediately*